### PR TITLE
Use token slices in signatures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ where
     fn sample_one_token(&mut self, mask: Mask) -> &str;
 
     /// Get the vocabulary of the `LangModel`, the list of all tokens.
-    fn get_vocabulary(&self) -> &Vec<Token>;
+    fn get_vocabulary(&self) -> &[Token];
 
     /// Sample up to `max_tokens` and append them to `text_buffer`. The selected
     /// masking algorithm will use `mask_algorithm` for its state.

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,13 +95,13 @@ fn main() -> Result<()> {
 
     let output = match cli.model {
         ModelSelector::Deterministic => {
-            let mut model = DeterministicModel::new(vocabulary);
+            let mut model = DeterministicModel::new(&vocabulary);
 
             sample_model(&mut model, max_tokens, &input_prompt, &algo)?
         }
         ModelSelector::RandomSample => {
             let rng = thread_rng();
-            let mut model = RandomSampleModel::new(vocabulary, rng);
+            let mut model = RandomSampleModel::new(&vocabulary, rng);
 
             sample_model(&mut model, max_tokens, &input_prompt, &algo)?
         }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -20,16 +20,16 @@ pub struct RandomSampleModel<R: Rng> {
 }
 
 impl<R: Rng> RandomSampleModel<R> {
-    pub fn new_with_weights(vocabulary: Vec<Token>, weights: &[f64], rng: R) -> Self {
+    pub fn new_with_weights(vocabulary: &[Token], weights: &[f64], rng: R) -> Self {
         RandomSampleModel {
-            vocabulary,
+            vocabulary: vocabulary.to_vec(),
             dist: WeightedIndex::new(weights).unwrap(),
             weights: weights.into(),
             rng,
         }
     }
 
-    pub fn new(vocabulary: Vec<Token>, rng: R) -> Self {
+    pub fn new(vocabulary: &[Token], rng: R) -> Self {
         let weights = vec![1.; vocabulary.len()];
         RandomSampleModel::new_with_weights(vocabulary, &weights, rng)
     }
@@ -53,7 +53,7 @@ impl<R: Rng> LangModel for RandomSampleModel<R> {
         &self.vocabulary[self.dist.sample(&mut self.rng)]
     }
 
-    fn get_vocabulary(&self) -> &Vec<Token> {
+    fn get_vocabulary(&self) -> &[Token] {
         &self.vocabulary
     }
 }
@@ -66,8 +66,11 @@ pub struct DeterministicModel {
 }
 
 impl DeterministicModel {
-    pub fn new(vocabulary: Vec<Token>) -> Self {
-        DeterministicModel { vocabulary, idx: 0 }
+    pub fn new(vocabulary: &[Token]) -> Self {
+        DeterministicModel {
+            vocabulary: vocabulary.to_vec(),
+            idx: 0,
+        }
     }
 }
 
@@ -97,7 +100,7 @@ impl LangModel for DeterministicModel {
         out_token
     }
 
-    fn get_vocabulary(&self) -> &Vec<Token> {
+    fn get_vocabulary(&self) -> &[Token] {
         &self.vocabulary
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,7 +18,7 @@ fn unmasked() {
     let (vocabulary, max_samples, _) = small_default_setup();
 
     // DeterministicModel
-    let mut determ = DeterministicModel::new(vocabulary.clone());
+    let mut determ = DeterministicModel::new(&vocabulary);
 
     let out = sample_model(
         &mut determ,
@@ -32,7 +32,7 @@ fn unmasked() {
 
     // RandomSampleModel
     let rng = SmallRng::seed_from_u64(42);
-    let mut const_logits = RandomSampleModel::new(vocabulary, rng);
+    let mut const_logits = RandomSampleModel::new(&vocabulary, rng);
 
     let out_rng = sample_model(
         &mut const_logits,
@@ -50,7 +50,7 @@ fn naive_mask() {
     // DeterministicModel
     let (vocabulary, max_samples, pattern) = small_default_setup();
 
-    let mut determ = DeterministicModel::new(vocabulary.clone());
+    let mut determ = DeterministicModel::new(&vocabulary);
 
     let out = sample_model(
         &mut determ,
@@ -64,7 +64,7 @@ fn naive_mask() {
 
     // RandomSampleModel
     let rng = SmallRng::seed_from_u64(42);
-    let mut const_logits = RandomSampleModel::new(vocabulary, rng);
+    let mut const_logits = RandomSampleModel::new(&vocabulary, rng);
 
     let out_rng = sample_model(
         &mut const_logits,
@@ -82,7 +82,7 @@ fn indexed_fsm_mask() {
     let (vocabulary, max_samples, pattern) = small_default_setup();
 
     // DeterministicModel
-    let mut determ = DeterministicModel::new(vocabulary.clone());
+    let mut determ = DeterministicModel::new(&vocabulary);
 
     let out = sample_model(
         &mut determ,
@@ -96,7 +96,7 @@ fn indexed_fsm_mask() {
 
     // RandomSampleModel
     let rng = SmallRng::seed_from_u64(42);
-    let mut const_logits = RandomSampleModel::new(vocabulary.clone(), rng);
+    let mut const_logits = RandomSampleModel::new(&vocabulary, rng);
 
     let out_rng = sample_model(
         &mut const_logits,
@@ -121,7 +121,7 @@ fn fsm_with_input_shorter() {
     let input_prompt = "AAAA";
 
     // DeterministicModel
-    let mut determ = DeterministicModel::new(vocabulary.clone());
+    let mut determ = DeterministicModel::new(&vocabulary);
 
     let out = sample_model(
         &mut determ,
@@ -136,7 +136,7 @@ fn fsm_with_input_shorter() {
 
     // RandomSampleModel
     let rng = SmallRng::seed_from_u64(42);
-    let mut const_logits = RandomSampleModel::new(vocabulary.clone(), rng);
+    let mut const_logits = RandomSampleModel::new(&vocabulary, rng);
 
     let out_rng = sample_model(
         &mut const_logits,


### PR DESCRIPTION
Use token slices in function signatures instead of owned vectors