### PR TITLE
Fix "0a token" bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,24 +397,16 @@ fn find_subsequences(fsm: &dense::DFA<Vec<u32>>, token: &Token) -> Result<Vec<St
         let mut state_sequence: StateSequence = vec![];
         let mut curr_state = state.id();
 
-        // Only keep the states that read token[0]
-        let peek_next = fsm.next_state(curr_state, token.as_bytes()[0]);
-        if fsm.is_special_state(peek_next)
-            && (fsm.is_dead_state(peek_next) || fsm.is_quit_state(peek_next))
-        {
-            continue 'states_loop;
-        }
-
         // Walk the FSM
         for &b in token.as_bytes() {
+            state_sequence.push(curr_state);
+            curr_state = fsm.next_state(curr_state, b);
             if fsm.is_special_state(curr_state)
                 && (fsm.is_dead_state(curr_state) || fsm.is_quit_state(curr_state))
             {
+                state_sequence.clear();
                 continue 'states_loop;
             }
-            state_sequence.push(curr_state);
-
-            curr_state = fsm.next_state(curr_state, b);
         }
         all_subseqs.push(state_sequence);
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,7 +6,7 @@ use structured_gen_rust::{
 };
 
 fn small_default_setup() -> (Vec<String>, usize, &'static str) {
-    let tokens = vec!["A", "3", ".", "42", "B", ".2", "1"];
+    let tokens = vec!["A", "3", ".", "42", "B", ".2", "1", "0a", "1b", "a."];
     let vocabulary: Vec<String> = tokens.into_iter().map(|s| s.to_owned()).collect();
     let max_samples = 15;
     let pattern = r"^([0-9]*)?\.?[0-9]*$";
@@ -46,7 +46,7 @@ fn unmasked() {
     )
     .unwrap();
 
-    insta::assert_snapshot!(out, @"A3.42B.21A3.42B.21A");
+    insta::assert_snapshot!(out, @"A3.42B.210a1ba.A3.42B");
 
     // RandomSampleModel
     let rng = SmallRng::seed_from_u64(42);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -60,7 +60,7 @@ fn unmasked() {
     )
     .unwrap();
 
-    insta::assert_snapshot!(out_rng, @"3...2423.42A33A.1.2");
+    insta::assert_snapshot!(out_rng, @"342.0a.2342BA..A421b0a");
 }
 
 #[test]


### PR DESCRIPTION
# Summary
An incorrect implementation of the FSM indexing algorithm was allowing invalid tokens such as `0a` for the "float" pattern `^([0-9]*)?\.?[0-9]*$`. This PR fixes this (issue https://github.com/f-forcher/structured-gen-rust/issues/31) and adds the tokens to the test vocabulary.